### PR TITLE
feat: add TablePgsqlUuidPKAttribute.php to work with pk uuid on postgres

### DIFF
--- a/src/Attributes/TablePgsqlUuidPKAttribute.php
+++ b/src/Attributes/TablePgsqlUuidPKAttribute.php
@@ -4,7 +4,6 @@ namespace ByJG\MicroOrm\Attributes;
 
 use Attribute;
 use ByJG\AnyDataset\Db\DbDriverInterface;
-use ByJG\MicroOrm\Literal\Literal;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class TablePgsqlUuidPKAttribute extends TableAttribute
@@ -12,7 +11,8 @@ class TablePgsqlUuidPKAttribute extends TableAttribute
     public function __construct(string $tableName)
     {
         parent::__construct($tableName, function (DbDriverInterface $dbDriver, object $entity) {
-            return bin2hex(random_bytes(16));
+            $bytes = random_bytes(16);
+            return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($bytes), 4));
         });
     }
 }

--- a/src/Attributes/TablePgsqlUuidPKAttribute.php
+++ b/src/Attributes/TablePgsqlUuidPKAttribute.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ByJG\MicroOrm\Attributes;
+
+use Attribute;
+use ByJG\AnyDataset\Db\DbDriverInterface;
+use ByJG\MicroOrm\Literal\Literal;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class TablePgsqlUuidPKAttribute extends TableAttribute
+{
+    public function __construct(string $tableName)
+    {
+        parent::__construct($tableName, function (DbDriverInterface $dbDriver, object $entity) {
+            return bin2hex(random_bytes(16));
+        });
+    }
+}


### PR DESCRIPTION
This Pull Request aims to fix the PDOException:
`
SQLSTATE[55000]: Object not in prerequisite state: 7 ERROR: lastval is not yet defined in this session`

that may occur when using PostgreSQL with UUIDs as primary keys.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add `TablePgsqlUuidPKAttribute.php` to support primary key UUIDs on PostgreSQL.

### Why are these changes being made?
This change introduces a new attribute class that facilitates the generation of UUIDs for primary keys in PostgreSQL databases, leveraging `bin2hex(random_bytes(16))` for UUID creation. The addition supports the need for universally unique primary keys in applications that interact with PostgreSQL, improving scalability and database portability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->