### PR TITLE
Add DISTINCT keyword support to Query classes

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -30,7 +30,7 @@ class Query extends QueryBasic
     public function groupBy(array $fields): static
     {
         $this->groupBy = array_merge($this->groupBy, $fields);
-    
+
         return $this;
     }
 
@@ -64,7 +64,7 @@ class Query extends QueryBasic
     public function forUpdate(): static
     {
         $this->forUpdate = true;
-        
+
         return $this;
     }
 
@@ -236,6 +236,10 @@ class Query extends QueryBasic
 
         if (!is_null($this->recursive)) {
             $queryBasic->withRecursive($this->recursive);
+        }
+
+        if ($this->distinct) {
+            $queryBasic->distinct();
         }
 
         return $queryBasic;

--- a/src/QueryBasic.php
+++ b/src/QueryBasic.php
@@ -19,6 +19,7 @@ class QueryBasic implements QueryBuilderInterface
     protected array $join = [];
     protected DbDriverInterface|null $dbDriver = null;
     protected ?Recursive $recursive = null;
+    protected bool $distinct = false;
 
     public static function getInstance(): QueryBasic
     {
@@ -172,6 +173,17 @@ class QueryBasic implements QueryBuilderInterface
     }
 
     /**
+     * Add DISTINCT keyword to the query
+     *
+     * @return $this
+     */
+    public function distinct(): static
+    {
+        $this->distinct = true;
+        return $this;
+    }
+
+    /**
      * @throws InvalidArgumentException
      */
     protected function getFields(): array
@@ -237,7 +249,7 @@ class QueryBasic implements QueryBuilderInterface
         }
         return [ $table . (!empty($alias) && $table != $alias ? " as " . $alias : ""), $params ];
     }   
-    
+
     /**
      * @param DbDriverInterface|null $dbDriver
      * @return SqlObject
@@ -258,9 +270,10 @@ class QueryBasic implements QueryBuilderInterface
         $params = array_merge($params, $paramsTable);
 
         $sql .= "SELECT " .
+            ($this->distinct ? "DISTINCT " : "") .
             $fieldList .
             "FROM " . $tableList;
-        
+
         $whereStr = $this->getWhere();
         if (!is_null($whereStr)) {
             $sql .= ' WHERE ' . $whereStr[0];

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -10,6 +10,7 @@ use ByJG\MicroOrm\Literal\Literal;
 use ByJG\MicroOrm\Mapper;
 use ByJG\MicroOrm\ORM;
 use ByJG\MicroOrm\Query;
+use ByJG\MicroOrm\QueryBasic;
 use ByJG\MicroOrm\Recursive;
 use ByJG\MicroOrm\SqlObject;
 use ByJG\MicroOrm\SqlObjectEnum;
@@ -596,5 +597,60 @@ class QueryTest extends TestCase
         // Test Unsafe
         $query->unsafe();
         $this->assertEquals(new SqlObject("DELETE FROM info WHERE iduser = :id", ["id" => 3], type: SqlObjectEnum::DELETE), $query->build());
+    }
+
+    public function testQueryBasicDistinct()
+    {
+        // Test without distinct
+        $queryBasic = QueryBasic::getInstance()
+            ->table('test')
+            ->fields(['fld1', 'fld2']);
+
+        $this->assertEquals(
+            new SqlObject('SELECT  fld1, fld2 FROM test'),
+            $queryBasic->build()
+        );
+
+        // Test with distinct
+        $queryBasic = QueryBasic::getInstance()
+            ->table('test')
+            ->fields(['fld1', 'fld2'])
+            ->distinct();
+
+        $this->assertEquals(
+            new SqlObject('SELECT DISTINCT  fld1, fld2 FROM test'),
+            $queryBasic->build()
+        );
+    }
+
+    public function testQueryDistinct()
+    {
+        // Test without distinct
+        $query = Query::getInstance()
+            ->table('test')
+            ->fields(['fld1', 'fld2']);
+
+        $this->assertEquals(
+            new SqlObject('SELECT  fld1, fld2 FROM test'),
+            $query->build()
+        );
+
+        // Test with distinct
+        $query = Query::getInstance()
+            ->table('test')
+            ->fields(['fld1', 'fld2'])
+            ->distinct();
+
+        $this->assertEquals(
+            new SqlObject('SELECT DISTINCT  fld1, fld2 FROM test'),
+            $query->build()
+        );
+
+        // Test getQueryBasic preserves distinct
+        $queryBasic = $query->getQueryBasic();
+        $this->assertEquals(
+            new SqlObject('SELECT DISTINCT  fld1, fld2 FROM test'),
+            $queryBasic->build()
+        );
     }
 }


### PR DESCRIPTION
Implemented support for the DISTINCT keyword in both `Query` and `QueryBasic` classes, enabling distinct queries. Added tests to confirm correctness and ensure compatibility across the classes.