### PR TITLE
feat: extend build methods to accept DbDriverInterface and add MySQL alias and subquery join tests

### DIFF
--- a/src/DeleteQuery.php
+++ b/src/DeleteQuery.php
@@ -2,6 +2,7 @@
 
 namespace ByJG\MicroOrm;
 
+use ByJG\AnyDataset\Db\DbDriverInterface;
 use ByJG\AnyDataset\Db\DbFunctionsInterface;
 use ByJG\MicroOrm\Exception\InvalidArgumentException;
 use ByJG\MicroOrm\Interface\QueryBuilderInterface;
@@ -13,7 +14,7 @@ class DeleteQuery extends Updatable
         return new DeleteQuery();
     }
 
-    public function build(DbFunctionsInterface $dbHelper = null): SqlObject
+    public function build(DbFunctionsInterface|DbDriverInterface|null $dbDriverOrHelper = null): SqlObject
     {
         $whereStr = $this->getWhere();
         if (is_null($whereStr)) {

--- a/src/InsertQuery.php
+++ b/src/InsertQuery.php
@@ -2,6 +2,7 @@
 
 namespace ByJG\MicroOrm;
 
+use ByJG\AnyDataset\Db\DbDriverInterface;
 use ByJG\AnyDataset\Db\DbFunctionsInterface;
 use ByJG\MicroOrm\Exception\InvalidArgumentException;
 use ByJG\MicroOrm\Exception\OrmInvalidFieldsException;
@@ -65,24 +66,28 @@ class InsertQuery extends Updatable
     }
 
     /**
-     * @param DbFunctionsInterface|null $dbHelper
+     * @param DbDriverInterface|DbFunctionsInterface|null $dbDriverOrHelper
      * @return SqlObject
      * @throws OrmInvalidFieldsException
      */
-    public function build(DbFunctionsInterface $dbHelper = null): SqlObject
+    public function build(DbFunctionsInterface|DbDriverInterface|null $dbDriverOrHelper = null): SqlObject
     {
         if (empty($this->values)) {
             throw new OrmInvalidFieldsException('You must specify the fields for insert');
         }
 
+        if ($dbDriverOrHelper instanceof DbDriverInterface) {
+            $dbDriverOrHelper = $dbDriverOrHelper->getDbHelper();
+        }
+
         $fieldsStr = array_keys($this->values); // get the fields from the first element only
-        if (!is_null($dbHelper)) {
-            $fieldsStr = $dbHelper->delimiterField($fieldsStr);
+        if (!is_null($dbDriverOrHelper)) {
+            $fieldsStr = $dbDriverOrHelper->delimiterField($fieldsStr);
         }
 
         $tableStr = $this->table;
-        if (!is_null($dbHelper)) {
-            $tableStr = $dbHelper->delimiterTable($tableStr);
+        if (!is_null($dbDriverOrHelper)) {
+            $tableStr = $dbDriverOrHelper->delimiterTable($tableStr);
         }
 
         $sql = 'INSERT INTO '

--- a/src/InsertSelectQuery.php
+++ b/src/InsertSelectQuery.php
@@ -2,6 +2,7 @@
 
 namespace ByJG\MicroOrm;
 
+use ByJG\AnyDataset\Db\DbDriverInterface;
 use ByJG\AnyDataset\Db\DbFunctionsInterface;
 use ByJG\MicroOrm\Exception\OrmInvalidFieldsException;
 use ByJG\MicroOrm\Interface\QueryBuilderInterface;
@@ -49,14 +50,18 @@ class InsertSelectQuery extends Updatable
     }
 
     /**
-     * @param DbFunctionsInterface|null $dbHelper
+     * @param DbDriverInterface|DbFunctionsInterface|null $dbDriverOrHelper
      * @return SqlObject
      * @throws OrmInvalidFieldsException
      */
-    public function build(DbFunctionsInterface $dbHelper = null): SqlObject
+    public function build(DbFunctionsInterface|DbDriverInterface|null $dbDriverOrHelper = null): SqlObject
     {
         if (empty($this->fields)) {
             throw new OrmInvalidFieldsException('You must specify the fields for insert');
+        }
+
+        if ($dbDriverOrHelper instanceof DbDriverInterface) {
+            $dbDriverOrHelper = $dbDriverOrHelper->getDbHelper();
         }
 
         if (empty($this->query) && empty($this->sqlObject)) {
@@ -66,13 +71,13 @@ class InsertSelectQuery extends Updatable
         }
 
         $fieldsStr = $this->fields;
-        if (!is_null($dbHelper)) {
-            $fieldsStr = $dbHelper->delimiterField($fieldsStr);
+        if (!is_null($dbDriverOrHelper)) {
+            $fieldsStr = $dbDriverOrHelper->delimiterField($fieldsStr);
         }
 
         $tableStr = $this->table;
-        if (!is_null($dbHelper)) {
-            $tableStr = $dbHelper->delimiterTable($tableStr);
+        if (!is_null($dbDriverOrHelper)) {
+            $tableStr = $dbDriverOrHelper->delimiterTable($tableStr);
         }
 
         $sql = 'INSERT INTO '

--- a/src/Interface/UpdateBuilderInterface.php
+++ b/src/Interface/UpdateBuilderInterface.php
@@ -8,7 +8,7 @@ use ByJG\MicroOrm\SqlObject;
 
 interface UpdateBuilderInterface
 {
-    public function build(?DbFunctionsInterface $dbHelper = null): SqlObject;
+    public function build(DbFunctionsInterface|DbDriverInterface|null $dbDriverOrHelper = null): SqlObject;
 
     public function buildAndExecute(DbDriverInterface $dbDriver, $params = [], ?DbFunctionsInterface $dbHelper = null);
 


### PR DESCRIPTION
The pull request introduces the following changes:
- Modify build methods to accept `DbDriverInterface`.
- Add tests for MySQL alias and subquery joins.

Please review the changes and provide feedback.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Extend the build methods across various query classes to accept both `DbDriverInterface` and `DbFunctionsInterface`, and add tests for MySQL alias and subquery joins in the `UpdateQueryTest`.

### Why are these changes being made?
The changes increase compatibility and flexibility by supporting both interfaces for providing database helpers. The added MySQL tests ensure that aliasing and subquery joins work correctly, addressing advanced query scenarios that can arise in complex database interactions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->