### PR TITLE
Add bulk transaction support and enhanced DB interface compatibility

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -34,6 +34,9 @@ jobs:
           --health-timeout=20s 
           --health-retries=10
 
+    env:
+      MYSQL_TEST_HOST: mysql
+
     steps:
       - uses: actions/checkout@v4
       - run: composer install

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,6 +20,20 @@ jobs:
           - "8.2"
           - "8.1"
 
+    services:
+      mysql:
+        image: mysql:8.0.20
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
+        ports:
+          - "3306:3306"
+        options: >-
+          --health-cmd="mysqladmin ping" 
+          --health-interval=10s 
+          --health-timeout=20s 
+          --health-retries=10
+
     steps:
       - uses: actions/checkout@v4
       - run: composer install

--- a/.idea/runConfigurations/MySQL_Server_Test.xml
+++ b/.idea/runConfigurations/MySQL_Server_Test.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="MySQL Server Test" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+    <deployment type="docker-compose.yml">
+      <settings>
+        <option name="sourceFilePath" value="docker-compose.yml" />
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/PHPUnit.xml
+++ b/.idea/runConfigurations/PHPUnit.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="PHPUnit" type="PHPUnitRunConfigurationType" factoryName="PHPUnit">
-    <TestRunner configuration_file="$PROJECT_DIR$/phpunit.xml.dist" scope="XML" />
+    <TestRunner configuration_file="$PROJECT_DIR$/phpunit.xml.dist" scope="XML" use_alternative_configuration_file="true" />
     <method v="2" />
   </configuration>
 </component>

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ $result = $repository->getByQuery($query);
 * [Using FieldAlias](docs/using-fieldalias.md)
 * [Tables without auto increments fields](docs/tables-without-auto-increment-fields.md)
 * [Using With Recursive SQL Command](docs/using-with-recursive-sql-command.md)
+* [QueryRaw (raw SQL)](docs/query-raw.md)
 
 ## Install
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  mysql:
+    image: mysql:8.0.20
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_AUTHENTICATION_PLUGIN=mysql_native_password
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      timeout: 20s
+      interval: 10s
+      retries: 10

--- a/docs/query-raw.md
+++ b/docs/query-raw.md
@@ -1,0 +1,83 @@
+# QueryRaw
+
+QueryRaw lets you execute a raw SQL statement while still benefiting from the repository pipeline (parameter binding,
+connection handling, iterators, and optional caching when used via SqlStatement).
+
+Important: QueryRaw does NOT generate or adapt SQL based on the DbDriver/DB dialect. It passes through exactly the SQL
+string you provide. That means the SQL you write must already be valid for the target database engine. Because of this,
+QueryRaw should be used only for very specific use cases where the high-level Query/Update/Insert/Delete builders cannot
+express what you need.
+
+When to use QueryRaw
+
+- Vendor-specific features that are not covered by the query builders (e.g., dialect functions, specialized hints).
+- One-off statements where you accept tight coupling to a single database dialect.
+- Chaining within bulk operations when you need to run a raw select right after a write.
+
+When NOT to use QueryRaw
+
+- Everyday selects/joins/filters/limits that can be expressed with Query or Union.
+- Inserts/updates/deletes that can be handled by InsertQuery/UpdateQuery/DeleteQuery.
+- Anywhere you want portability across databases or automatic dialect handling.
+
+Behavior
+
+- build(): returns a SqlObject with your SQL and parameters unchanged. The optional DbDriver parameter is ignored for
+  SQL generation.
+- buildAndGetIterator($dbDriver): executes your SQL against the provided driver and returns a GenericIterator.
+- Parameter binding: pass parameters as an array (named or positional) and the underlying driver will bind them.
+
+Examples
+
+1) Basic raw select returning rows as arrays
+
+```php
+use ByJG\MicroOrm\QueryRaw;
+
+$query = QueryRaw::getInstance(
+    'select id, name from users where name like :part',
+    ['part' => 'A%']
+);
+
+$rows = $repository->getByQueryRaw($query); // array<array<string, mixed>>
+```
+
+2) Using dialect-specific functions (DB-specific SQL)
+
+```php
+// Example for SQLite using julianday(); not portable to other databases
+$query = QueryRaw::getInstance(
+    "select name, julianday('2020-06-28') - julianday(createdate) as days from users limit 1"
+);
+
+$rows = $repository->getByQueryRaw($query);
+// e.g., [ [ 'name' => 'Jane Doe', 'days' => 1271.0 ] ]
+```
+
+3) Bulk execution: insert followed by selecting last inserted id
+
+```php
+use ByJG\MicroOrm\InsertQuery;
+use ByJG\MicroOrm\QueryRaw;
+
+$insert = InsertQuery::getInstance('users', [
+    'name' => 'Charlie',
+    'createdate' => '2025-01-01',
+]);
+
+// Use DB helper to get the correct SQL for your driver
+$selectLastId = QueryRaw::getInstance(
+    $repository->getDbDriver()->getDbHelper()->getSqlLastInsertId()
+);
+
+$it = $repository->bulkExecute([$insert, $selectLastId]);
+$result = $it->toArray();
+// $result is the rows from the last statement (the select)
+```
+
+Notes
+
+- QueryRaw ties your code to the specific SQL dialect you write. If you switch databases, you may need to rewrite the
+  raw SQL.
+- Always use bound parameters to avoid SQL injection; pass them in the second argument to getInstance().
+- For portable queries, prefer Query/Union and the provided Insert/Update/Delete builders.

--- a/src/DeleteQuery.php
+++ b/src/DeleteQuery.php
@@ -2,6 +2,7 @@
 
 namespace ByJG\MicroOrm;
 
+use ByJG\AnyDataset\Db\DbDriverInterface;
 use ByJG\AnyDataset\Db\DbFunctionsInterface;
 use ByJG\MicroOrm\Exception\InvalidArgumentException;
 use ByJG\MicroOrm\Interface\QueryBuilderInterface;
@@ -13,7 +14,7 @@ class DeleteQuery extends Updatable
         return new DeleteQuery();
     }
 
-    public function build(DbFunctionsInterface $dbHelper = null): SqlObject
+    public function build(DbFunctionsInterface|DbDriverInterface|null $dbDriverOrHelper = null): SqlObject
     {
         $whereStr = $this->getWhere();
         if (is_null($whereStr)) {

--- a/src/InsertQuery.php
+++ b/src/InsertQuery.php
@@ -2,6 +2,7 @@
 
 namespace ByJG\MicroOrm;
 
+use ByJG\AnyDataset\Db\DbDriverInterface;
 use ByJG\AnyDataset\Db\DbFunctionsInterface;
 use ByJG\MicroOrm\Exception\InvalidArgumentException;
 use ByJG\MicroOrm\Exception\OrmInvalidFieldsException;
@@ -65,24 +66,28 @@ class InsertQuery extends Updatable
     }
 
     /**
-     * @param DbFunctionsInterface|null $dbHelper
+     * @param DbDriverInterface|DbFunctionsInterface|null $dbDriverOrHelper
      * @return SqlObject
      * @throws OrmInvalidFieldsException
      */
-    public function build(DbFunctionsInterface $dbHelper = null): SqlObject
+    public function build(DbFunctionsInterface|DbDriverInterface|null $dbDriverOrHelper = null): SqlObject
     {
         if (empty($this->values)) {
             throw new OrmInvalidFieldsException('You must specify the fields for insert');
         }
 
+        if ($dbDriverOrHelper instanceof DbDriverInterface) {
+            $dbDriverOrHelper = $dbDriverOrHelper->getDbHelper();
+        }
+
         $fieldsStr = array_keys($this->values); // get the fields from the first element only
-        if (!is_null($dbHelper)) {
-            $fieldsStr = $dbHelper->delimiterField($fieldsStr);
+        if (!is_null($dbDriverOrHelper)) {
+            $fieldsStr = $dbDriverOrHelper->delimiterField($fieldsStr);
         }
 
         $tableStr = $this->table;
-        if (!is_null($dbHelper)) {
-            $tableStr = $dbHelper->delimiterTable($tableStr);
+        if (!is_null($dbDriverOrHelper)) {
+            $tableStr = $dbDriverOrHelper->delimiterTable($tableStr);
         }
 
         $sql = 'INSERT INTO '

--- a/src/InsertSelectQuery.php
+++ b/src/InsertSelectQuery.php
@@ -2,6 +2,7 @@
 
 namespace ByJG\MicroOrm;
 
+use ByJG\AnyDataset\Db\DbDriverInterface;
 use ByJG\AnyDataset\Db\DbFunctionsInterface;
 use ByJG\MicroOrm\Exception\OrmInvalidFieldsException;
 use ByJG\MicroOrm\Interface\QueryBuilderInterface;
@@ -49,14 +50,18 @@ class InsertSelectQuery extends Updatable
     }
 
     /**
-     * @param DbFunctionsInterface|null $dbHelper
+     * @param DbDriverInterface|DbFunctionsInterface|null $dbDriverOrHelper
      * @return SqlObject
      * @throws OrmInvalidFieldsException
      */
-    public function build(DbFunctionsInterface $dbHelper = null): SqlObject
+    public function build(DbFunctionsInterface|DbDriverInterface|null $dbDriverOrHelper = null): SqlObject
     {
         if (empty($this->fields)) {
             throw new OrmInvalidFieldsException('You must specify the fields for insert');
+        }
+
+        if ($dbDriverOrHelper instanceof DbDriverInterface) {
+            $dbDriverOrHelper = $dbDriverOrHelper->getDbHelper();
         }
 
         if (empty($this->query) && empty($this->sqlObject)) {
@@ -66,13 +71,13 @@ class InsertSelectQuery extends Updatable
         }
 
         $fieldsStr = $this->fields;
-        if (!is_null($dbHelper)) {
-            $fieldsStr = $dbHelper->delimiterField($fieldsStr);
+        if (!is_null($dbDriverOrHelper)) {
+            $fieldsStr = $dbDriverOrHelper->delimiterField($fieldsStr);
         }
 
         $tableStr = $this->table;
-        if (!is_null($dbHelper)) {
-            $tableStr = $dbHelper->delimiterTable($tableStr);
+        if (!is_null($dbDriverOrHelper)) {
+            $tableStr = $dbDriverOrHelper->delimiterTable($tableStr);
         }
 
         $sql = 'INSERT INTO '

--- a/src/Interface/UpdateBuilderInterface.php
+++ b/src/Interface/UpdateBuilderInterface.php
@@ -8,7 +8,7 @@ use ByJG\MicroOrm\SqlObject;
 
 interface UpdateBuilderInterface
 {
-    public function build(?DbFunctionsInterface $dbHelper = null): SqlObject;
+    public function build(DbFunctionsInterface|DbDriverInterface|null $dbDriverOrHelper = null): SqlObject;
 
     public function buildAndExecute(DbDriverInterface $dbDriver, $params = [], ?DbFunctionsInterface $dbHelper = null);
 

--- a/src/QueryBasic.php
+++ b/src/QueryBasic.php
@@ -272,7 +272,7 @@ class QueryBasic implements QueryBuilderInterface
         $sql .= "SELECT " .
             ($this->distinct ? "DISTINCT " : "") .
             $fieldList .
-            "FROM " . $tableList;
+            (!empty($tableList) ? "FROM " . $tableList : "");
 
         $whereStr = $this->getWhere();
         if (!is_null($whereStr)) {

--- a/src/QueryRaw.php
+++ b/src/QueryRaw.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ByJG\MicroOrm;
+
+use ByJG\AnyDataset\Core\GenericIterator;
+use ByJG\AnyDataset\Db\DbDriverInterface;
+
+class QueryRaw implements Interface\QueryBuilderInterface
+{
+
+    protected function __construct(protected string $sql, protected array $parameters = [])
+    {
+    }
+
+    public static function getInstance(string $sql, array $parameters = []): QueryRaw
+    {
+        return new self($sql, $parameters);
+    }
+
+    public function build(?DbDriverInterface $dbDriver = null): SqlObject
+    {
+        return new SqlObject($this->sql, $this->parameters);
+    }
+
+    public function buildAndGetIterator(?DbDriverInterface $dbDriver = null, ?CacheQueryResult $cache = null): GenericIterator
+    {
+        return $dbDriver->getIterator($this->sql, $this->parameters);
+    }
+}

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -236,22 +236,20 @@ class Repository
             }
 
             // For write statements, avoid parameter name collisions by uniquifying named params
-//            if (!empty($params)) {
-                foreach ($params as $key => $value) {
-                    // Only process named parameters (string keys)
-                    if (isset($bigParams[$key])) {
-                        $uniqueKey = $key . '__b' . $i;
-                        // Replace ":key" with ":key__b{i}" using a safe regex that avoids partial matches
-                        $pattern = '/(?<!:):' . preg_quote($key, '/') . '(?![A-Za-z0-9_])/';
-                        $replacement = ':' . $uniqueKey;
-                        $sql = preg_replace($pattern, $replacement, $sql);
-                        $bigParams[$uniqueKey] = $value;
-                    } else {
-                        // Positional parameter or numeric key; just carry over
-                        $bigParams[$key] = $value;
-                    }
+            foreach ($params as $key => $value) {
+                // Only process named parameters (string keys)
+                if (isset($bigParams[$key])) {
+                    $uniqueKey = $key . '__b' . $i;
+                    // Replace ":key" with ":key__b{i}" using a safe regex that avoids partial matches
+                    $pattern = '/(?<!:):' . preg_quote($key, '/') . '(?![A-Za-z0-9_])/';
+                    $replacement = ':' . $uniqueKey;
+                    $sql = preg_replace($pattern, $replacement, $sql);
+                    $bigParams[$uniqueKey] = $value;
+                } else {
+                    // Positional parameter or numeric key; just carry over
+                    $bigParams[$key] = $value;
                 }
-//            }
+            }
 
             $bigSqlWrites .= rtrim($sql, "; \t\n\r\0\x0B") . ";\n";
         }

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -197,7 +197,7 @@ class Repository
      *
      * @param array<int, Updatable|QueryBuilderInterface> $queries List of queries to be executed in bulk
      * @param IsolationLevelEnum|null $isolationLevel
-     * @return void
+     * @return GenericIterator|null
      * @throws InvalidArgumentException
      * @throws RepositoryReadOnlyException
      * @throws Throwable

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -236,7 +236,7 @@ class Repository
                             $replacement = (string)$value;
                         } else {
                             // Strings and others: use PDO quote if available, otherwise fallback to single-quoted with basic escaping
-                            $quoted = method_exists($pdo, 'quote') && $pdo ? $pdo->quote((string)$value) : ("'" . str_replace("'", "''", (string)$value) . "'");
+                            $quoted = method_exists($pdo, 'quote') ? $pdo->quote((string)$value) : ("'" . str_replace("'", "''", (string)$value) . "'");
                             $replacement = $quoted;
                         }
                     }

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -410,12 +410,11 @@ class Repository
      * @param mixed $instance
      * @param UpdateConstraint|null $updateConstraint
      * @return mixed
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      * @throws OrmBeforeInvalidException
      * @throws OrmInvalidFieldsException
      * @throws RepositoryReadOnlyException
      * @throws UpdateConstraintException
-     * @throws \ByJG\Serializer\Exception\InvalidArgumentException
      */
     public function save(mixed $instance, UpdateConstraint $updateConstraint = null): mixed
     {

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -232,7 +232,7 @@ class Repository
             if ($isSelect && $i === array_key_last($queries)) {
                 // Trailing SELECT: keep it separate with its own params
                 $selectSql = rtrim($sql, "; \t\n\r\0\x0B");
-                $selectParams = $params ?? [];
+                $selectParams = $params;
                 continue;
             }
 
@@ -256,7 +256,7 @@ class Repository
                 $params = $newParams;
             }
 
-            $bigParams = array_merge($bigParams, $params ?? []);
+            $bigParams = array_merge($bigParams, $params);
             $bigSqlWrites .= rtrim($sql, "; \t\n\r\0\x0B") . ";\n";
         }
 

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -211,7 +211,6 @@ class Repository
         }
 
         $dbDriver = $this->getDbDriverWrite();
-        $pdo = $dbDriver->getDbConnection();
 
         $bigSqlWrites = '';
         $selectSql = null;
@@ -237,26 +236,23 @@ class Repository
             }
 
             // For write statements, avoid parameter name collisions by uniquifying named params
-            if (!empty($params)) {
-                $newParams = [];
+//            if (!empty($params)) {
                 foreach ($params as $key => $value) {
                     // Only process named parameters (string keys)
-                    if (is_string($key)) {
+                    if (isset($bigParams[$key])) {
                         $uniqueKey = $key . '__b' . $i;
                         // Replace ":key" with ":key__b{i}" using a safe regex that avoids partial matches
                         $pattern = '/(?<!:):' . preg_quote($key, '/') . '(?![A-Za-z0-9_])/';
                         $replacement = ':' . $uniqueKey;
                         $sql = preg_replace($pattern, $replacement, $sql);
-                        $newParams[$uniqueKey] = $value;
+                        $bigParams[$uniqueKey] = $value;
                     } else {
                         // Positional parameter or numeric key; just carry over
-                        $newParams[$key] = $value;
+                        $bigParams[$key] = $value;
                     }
                 }
-                $params = $newParams;
-            }
+//            }
 
-            $bigParams = array_merge($bigParams, $params);
             $bigSqlWrites .= rtrim($sql, "; \t\n\r\0\x0B") . ";\n";
         }
 

--- a/src/UpdateQuery.php
+++ b/src/UpdateQuery.php
@@ -59,7 +59,7 @@ class UpdateQuery extends Updatable
      * @param string $value
      * @return $this
      */
-    public function setLiteral(string $field, string $value): UpdateQuery
+    public function setLiteral(string $field, mixed $value): UpdateQuery
     {
         $this->set[$field] = new Literal($value);
         return $this;

--- a/src/WhereTrait.php
+++ b/src/WhereTrait.php
@@ -9,6 +9,7 @@ trait WhereTrait
 {
     protected array $where = [];
     protected bool $unsafe = false;
+    private static int $whereInCounter = 0;
 
     /**
      * Example:
@@ -110,7 +111,7 @@ trait WhereTrait
         }
 
         // Generate a unique prefix for this whereIn call
-        $uniquePrefix = 'in_' . md5($field . microtime(true)) . '_';
+        $uniquePrefix = 'in_' . $field . '_' . (++self::$whereInCounter) . '_';
         
         $placeholders = [];
         $params = [];

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -13,13 +13,12 @@ use ByJG\MicroOrm\Query;
 use ByJG\MicroOrm\QueryRaw;
 use ByJG\MicroOrm\Repository;
 use ByJG\MicroOrm\UpdateQuery;
-use ByJG\Util\Uri;
 use PHPUnit\Framework\TestCase;
 use Tests\Model\Users;
 
 class BulkTest extends TestCase
 {
-    const URI = 'sqlite:///tmp/test-bulk.db';
+    const URI = 'mysql://root:password@127.0.0.1';
 
     protected DbDriverInterface $dbDriver;
     protected Repository $repository;
@@ -27,10 +26,12 @@ class BulkTest extends TestCase
     protected function setUp(): void
     {
         $this->dbDriver = Factory::getDbInstance(self::URI);
+        $this->dbDriver->execute('create database if not exists testmicroorm;');
+        $this->dbDriver = Factory::getDbInstance(self::URI . '/testmicroorm');
 
         // Create table and seed data similar to RepositoryTest
         $this->dbDriver->execute('create table users (
-            id integer primary key  autoincrement,
+            id integer primary key  auto_increment,
             name varchar(45),
             createdate datetime);'
         );
@@ -46,8 +47,7 @@ class BulkTest extends TestCase
 
     protected function tearDown(): void
     {
-        $uri = new Uri(self::URI);
-        @unlink($uri->getPath());
+        $this->dbDriver->execute('drop table users');
     }
 
     public function testBulkMixedQueriesWithParamCollision(): void

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use ByJG\AnyDataset\Db\DbDriverInterface;
-use ByJG\AnyDataset\Db\Factory;
 use ByJG\MicroOrm\DeleteQuery;
 use ByJG\MicroOrm\Exception\InvalidArgumentException;
 use ByJG\MicroOrm\InsertBulkQuery;
@@ -18,16 +17,12 @@ use Tests\Model\Users;
 
 class BulkTest extends TestCase
 {
-    const URI = 'mysql://root:password@127.0.0.1';
-
     protected DbDriverInterface $dbDriver;
     protected Repository $repository;
 
     protected function setUp(): void
     {
-        $this->dbDriver = Factory::getDbInstance(self::URI);
-        $this->dbDriver->execute('create database if not exists testmicroorm;');
-        $this->dbDriver = Factory::getDbInstance(self::URI . '/testmicroorm');
+        $this->dbDriver = ConnectionUtil::getConnection('testmicroorm');
 
         // Create table and seed data similar to RepositoryTest
         $this->dbDriver->execute('create table users (

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests;
+
+use ByJG\AnyDataset\Db\DbDriverInterface;
+use ByJG\AnyDataset\Db\Factory;
+use ByJG\MicroOrm\DeleteQuery;
+use ByJG\MicroOrm\Exception\InvalidArgumentException;
+use ByJG\MicroOrm\InsertBulkQuery;
+use ByJG\MicroOrm\InsertQuery;
+use ByJG\MicroOrm\Mapper;
+use ByJG\MicroOrm\Query;
+use ByJG\MicroOrm\Repository;
+use ByJG\MicroOrm\UpdateQuery;
+use ByJG\Util\Uri;
+use PHPUnit\Framework\TestCase;
+use Tests\Model\Users;
+
+class BulkTest extends TestCase
+{
+    const URI = 'sqlite:///tmp/test-bulk.db';
+
+    protected DbDriverInterface $dbDriver;
+    protected Repository $repository;
+
+    protected function setUp(): void
+    {
+        $this->dbDriver = Factory::getDbInstance(self::URI);
+
+        // Create table and seed data similar to RepositoryTest
+        $this->dbDriver->execute('create table users (
+            id integer primary key  autoincrement,
+            name varchar(45),
+            createdate datetime);'
+        );
+        $insertBulk = InsertBulkQuery::getInstance('users', ['name', 'createdate']);
+        $insertBulk->values(['name' => 'John Doe', 'createdate' => '2017-01-02']);
+        $insertBulk->values(['name' => 'Jane Doe', 'createdate' => '2017-01-04']);
+        $insertBulk->values(['name' => 'JG', 'createdate' => '1974-01-26']);
+        $insertBulk->buildAndExecute($this->dbDriver);
+
+        $mapper = new Mapper(Users::class, 'users', 'Id');
+        $this->repository = new Repository($this->dbDriver, $mapper);
+    }
+
+    protected function tearDown(): void
+    {
+        $uri = new Uri(self::URI);
+        @unlink($uri->getPath());
+    }
+
+    public function testBulkMixedQueriesWithParamCollision(): void
+    {
+        // Sanity check: count, specific rows
+        // 3 initial rows
+        $count = Query::getInstance()->fields(['count(*) as cnt'])->table('users');
+        $res = $this->repository->getByQueryRaw($count);
+        $this->assertEquals(3, (int)$res[0]['cnt']);
+
+        // id=1 should have name 'John Doe'
+        $row = $this->repository->get(1);
+        $this->assertEquals('John Doe', $row->getName());
+
+        // The 'Alice' should not exist
+        $rows = $this->repository->getByFilter('name = :name', ['name' => 'Alice']);
+        $this->assertCount(0, $rows);
+
+        // The 'JG' should exist before bulk
+        $rows = $this->repository->getByFilter('name = :name', ['name' => 'JG']);
+        $this->assertCount(1, $rows);
+
+        // Prepare queries with overlapping parameter names (:name used in multiple queries)
+        $insert = InsertQuery::getInstance('users', [
+            'name' => 'Alice',
+            'createdate' => '2020-01-01'
+        ]);
+
+        $update = UpdateQuery::getInstance()
+            ->table('users')
+            ->set('name', 'Bob')
+            ->where('id = :id', ['id' => 1]);
+
+        $delete = DeleteQuery::getInstance()
+            ->table('users')
+            ->where('name = :name', ['name' => 'JG']);
+
+        // Execute bulk
+        $this->repository->bulkExecute([$insert, $update, $delete], null);
+
+        // Validate results: count, specific rows
+        // 3 initial + 1 insert - 1 delete = 3 rows
+        $count = Query::getInstance()->fields(['count(*) as cnt'])->table('users');
+        $res = $this->repository->getByQueryRaw($count);
+        $this->assertEquals(3, (int)$res[0]['cnt']);
+
+        // id=1 should now have name 'Bob'
+        $row = $this->repository->get(1);
+        $this->assertEquals('Bob', $row->getName());
+
+        // The newly inserted 'Alice' should exist
+        $rows = $this->repository->getByFilter('name = :name', ['name' => 'Alice']);
+        $this->assertCount(1, $rows);
+
+        // The deleted 'JG' should be gone
+        $rows = $this->repository->getByFilter('name = :name', ['name' => 'JG']);
+        $this->assertCount(0, $rows);
+    }
+
+    public function testBulkEmptyArray(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('You pass an empty array to bulk');
+
+        // Should not throw and not change anything
+        $this->repository->bulkExecute([], null);
+    }
+
+    public function testBulkMixedQueriesWithInvalidQuery(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid query type. Expected QueryBuilderInterface or Updatable.');
+
+        // Prepare queries with overlapping parameter names (:name used in multiple queries)
+        $insert = InsertQuery::getInstance('users', [
+            'name' => 'Alice',
+            'createdate' => '2020-01-01'
+        ]);
+
+        $update = UpdateQuery::getInstance()
+            ->table('users')
+            ->set('name', 'Bob')
+            ->where('id = :id', ['id' => 1]);
+
+        $delete = DeleteQuery::getInstance()
+            ->table('users')
+            ->where('name = :name', ['name' => 'JG']);
+
+        $invalid = "invalid";
+
+        // Execute bulk
+        $this->repository->bulkExecute([$insert, $invalid, $update, $delete], null);
+    }
+
+}

--- a/tests/BulkTest.php
+++ b/tests/BulkTest.php
@@ -140,6 +140,7 @@ class BulkTest extends TestCase
         $invalid = "invalid";
 
         // Execute bulk
+        /** @psalm-suppress InvalidArgument */
         $this->repository->bulkExecute([$insert, $invalid, $update, $delete], null);
     }
 

--- a/tests/ConnectionUtil.php
+++ b/tests/ConnectionUtil.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests;
+
+use ByJG\AnyDataset\Db\DbDriverInterface;
+use ByJG\AnyDataset\Db\Factory;
+use ByJG\Util\Uri;
+
+class ConnectionUtil
+{
+    public static function getConnection(string $database): DbDriverInterface
+    {
+        $dbDriver = Factory::getDbInstance(ConnectionUtil::getUri());
+        $dbDriver->execute("create database if not exists $database;");
+        return Factory::getDbInstance(ConnectionUtil::getUri($database));
+    }
+
+    public static function getUri(?string $database = null): Uri
+    {
+        $host = getenv('MYSQL_TEST_HOST') ? getenv('MYSQL_TEST_HOST') : '127.0.0.1';
+        $uri = new Uri("mysql://root:password@$host");
+
+        if (empty($database)) {
+            return $uri;
+        }
+
+        return $uri->withPath("/$database");
+    }
+}

--- a/tests/Model/UsersWithUuidKey.php
+++ b/tests/Model/UsersWithUuidKey.php
@@ -3,10 +3,10 @@
 namespace Tests\Model;
 
 use ByJG\MicroOrm\Attributes\FieldAttribute;
-use ByJG\MicroOrm\Attributes\TableSqliteUuidPKAttribute;
+use ByJG\MicroOrm\Attributes\TableMySqlUuidPKAttribute;
 use ByJG\MicroOrm\Literal\Literal;
 
-#[TableSqliteUuidPKAttribute(tableName: 'usersuuid')]
+#[TableMySqlUuidPKAttribute(tableName: 'usersuuid')]
 class UsersWithUuidKey
 {
     #[FieldAttribute(primaryKey: true)]

--- a/tests/RepositoryAliasTest.php
+++ b/tests/RepositoryAliasTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use ByJG\AnyDataset\Db\DbDriverInterface;
-use ByJG\AnyDataset\Db\Factory;
 use ByJG\MicroOrm\FieldMapping;
 use ByJG\MicroOrm\Mapper;
 use ByJG\MicroOrm\Query;
@@ -13,9 +12,6 @@ use Tests\Model\Customer;
 
 class RepositoryAliasTest extends TestCase
 {
-
-    const URI = 'mysql://root:password@127.0.0.1';
-
     /**
      * @var Mapper
      */
@@ -33,9 +29,7 @@ class RepositoryAliasTest extends TestCase
 
     public function setUp(): void
     {
-        $this->dbDriver = Factory::getDbInstance(self::URI);
-        $this->dbDriver->execute('create database if not exists testmicroorm;');
-        $this->dbDriver = Factory::getDbInstance(self::URI . "/testmicroorm");
+        $this->dbDriver = ConnectionUtil::getConnection("testmicroorm");
 
         $this->dbDriver->execute('create table customers (
             id integer primary key  auto_increment,

--- a/tests/RepositoryAliasTest.php
+++ b/tests/RepositoryAliasTest.php
@@ -8,14 +8,13 @@ use ByJG\MicroOrm\FieldMapping;
 use ByJG\MicroOrm\Mapper;
 use ByJG\MicroOrm\Query;
 use ByJG\MicroOrm\Repository;
-use ByJG\Util\Uri;
 use PHPUnit\Framework\TestCase;
 use Tests\Model\Customer;
 
 class RepositoryAliasTest extends TestCase
 {
 
-    const URI='sqlite:///tmp/teste.db';
+    const URI = 'mysql://root:password@127.0.0.1';
 
     /**
      * @var Mapper
@@ -35,9 +34,11 @@ class RepositoryAliasTest extends TestCase
     public function setUp(): void
     {
         $this->dbDriver = Factory::getDbInstance(self::URI);
+        $this->dbDriver->execute('create database if not exists testmicroorm;');
+        $this->dbDriver = Factory::getDbInstance(self::URI . "/testmicroorm");
 
         $this->dbDriver->execute('create table customers (
-            id integer primary key  autoincrement,
+            id integer primary key  auto_increment,
             customer_name varchar(45),
             customer_age int);'
         );
@@ -58,8 +59,7 @@ class RepositoryAliasTest extends TestCase
 
     public function tearDown(): void
     {
-        $uri = new Uri(self::URI);
-        unlink($uri->getPath());
+        $this->dbDriver->execute('drop table if exists customers;');
     }
 
     public function testGet()

--- a/tests/RepositoryPkListTest.php
+++ b/tests/RepositoryPkListTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use ByJG\AnyDataset\Db\DbDriverInterface;
-use ByJG\AnyDataset\Db\Factory;
 use ByJG\MicroOrm\Mapper;
 use ByJG\MicroOrm\Repository;
 use PHPUnit\Framework\TestCase;
@@ -11,9 +10,6 @@ use Tests\Model\Items;
 
 class RepositoryPkListTest extends TestCase
 {
-
-    const URI = 'mysql://root:password@127.0.0.1';
-
     /**
      * @var Mapper
      */
@@ -31,9 +27,7 @@ class RepositoryPkListTest extends TestCase
 
     public function setUp(): void
     {
-        $this->dbDriver = Factory::getDbInstance(self::URI);
-        $this->dbDriver->execute('create database if not exists testmicroorm;');
-        $this->dbDriver = Factory::getDbInstance(self::URI . "/testmicroorm");
+        $this->dbDriver = ConnectionUtil::getConnection("testmicroorm");
 
         $this->dbDriver->execute('CREATE TABLE items (
             storeid INTEGER,

--- a/tests/RepositoryPkListTest.php
+++ b/tests/RepositoryPkListTest.php
@@ -6,14 +6,13 @@ use ByJG\AnyDataset\Db\DbDriverInterface;
 use ByJG\AnyDataset\Db\Factory;
 use ByJG\MicroOrm\Mapper;
 use ByJG\MicroOrm\Repository;
-use ByJG\Util\Uri;
 use PHPUnit\Framework\TestCase;
 use Tests\Model\Items;
 
 class RepositoryPkListTest extends TestCase
 {
 
-    const URI='sqlite:///tmp/teste.db';
+    const URI = 'mysql://root:password@127.0.0.1';
 
     /**
      * @var Mapper
@@ -33,6 +32,8 @@ class RepositoryPkListTest extends TestCase
     public function setUp(): void
     {
         $this->dbDriver = Factory::getDbInstance(self::URI);
+        $this->dbDriver->execute('create database if not exists testmicroorm;');
+        $this->dbDriver = Factory::getDbInstance(self::URI . "/testmicroorm");
 
         $this->dbDriver->execute('CREATE TABLE items (
             storeid INTEGER,
@@ -52,8 +53,7 @@ class RepositoryPkListTest extends TestCase
 
     public function tearDown(): void
     {
-        $uri = new Uri(self::URI);
-        unlink($uri->getPath());
+        $this->dbDriver->execute('drop table if exists items;');
     }
 
     public function testGet()

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -30,7 +30,6 @@ use ByJG\MicroOrm\SqlObjectEnum;
 use ByJG\MicroOrm\Union;
 use ByJG\MicroOrm\UpdateConstraint;
 use ByJG\MicroOrm\UpdateQuery;
-use ByJG\Util\Uri;
 use DateTime;
 use Exception;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -46,7 +45,7 @@ use Throwable;
 class RepositoryTest extends TestCase
 {
 
-    const URI='sqlite:///tmp/test.db';
+    const URI = 'mysql://root:password@127.0.0.1';
 
     /**
      * @var Mapper
@@ -71,9 +70,11 @@ class RepositoryTest extends TestCase
     public function setUp(): void
     {
         $this->dbDriver = Factory::getDbInstance(self::URI);
+        $this->dbDriver->execute('create database if not exists testmicroorm;');
+        $this->dbDriver = Factory::getDbInstance(self::URI . "/testmicroorm");
 
         $this->dbDriver->execute('create table users (
-            id integer primary key  autoincrement,
+            id integer primary key  auto_increment,
             name varchar(45),
             createdate datetime);'
         );
@@ -86,11 +87,11 @@ class RepositoryTest extends TestCase
 
 
         $this->dbDriver->execute('create table info (
-            id integer primary key  autoincrement,
+            id integer primary key  auto_increment,
             iduser INTEGER,
-            property number(10,2),
-            created_at datetime,
-            updated_at datetime,
+            property decimal(10, 2),
+            created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             deleted_at datetime);'
         );
         $insertMultiple = InsertBulkQuery::getInstance('info', ['iduser', 'property']);
@@ -107,8 +108,8 @@ class RepositoryTest extends TestCase
 
     public function tearDown(): void
     {
-        $uri = new Uri(self::URI);
-        unlink($uri->getPath());
+        $this->dbDriver->execute('drop table if exists users;');
+        $this->dbDriver->execute('drop table if exists info;');
         ORM::clearRelationships();
     }
 
@@ -117,17 +118,17 @@ class RepositoryTest extends TestCase
         $users = $this->repository->get(1);
         $this->assertEquals(1, $users->getId());
         $this->assertEquals('John Doe', $users->getName());
-        $this->assertEquals('2017-01-02', $users->getCreatedate());
+        $this->assertEquals('2017-01-02 00:00:00', $users->getCreatedate());
 
         $users = $this->repository->get("2");
         $this->assertEquals(2, $users->getId());
         $this->assertEquals('Jane Doe', $users->getName());
-        $this->assertEquals('2017-01-04', $users->getCreatedate());
+        $this->assertEquals('2017-01-04 00:00:00', $users->getCreatedate());
 
         $users = $this->repository->get(new Literal(1));
         $this->assertEquals(1, $users->getId());
         $this->assertEquals('John Doe', $users->getName());
-        $this->assertEquals('2017-01-02', $users->getCreatedate());
+        $this->assertEquals('2017-01-02 00:00:00', $users->getCreatedate());
     }
 
     public function testGetByFilter()
@@ -136,7 +137,7 @@ class RepositoryTest extends TestCase
         $this->assertCount(1, $users);
         $this->assertEquals(1, $users[0]->getId());
         $this->assertEquals('John Doe', $users[0]->getName());
-        $this->assertEquals('2017-01-02', $users[0]->getCreatedate());
+        $this->assertEquals('2017-01-02 00:00:00', $users[0]->getCreatedate());
 
         $filter = new IteratorFilter();
         $filter->and('id', Relation::EQUAL, 2);
@@ -144,7 +145,7 @@ class RepositoryTest extends TestCase
         $this->assertCount(1, $users);
         $this->assertEquals(2, $users[0]->getId());
         $this->assertEquals('Jane Doe', $users[0]->getName());
-        $this->assertEquals('2017-01-04', $users[0]->getCreatedate());
+        $this->assertEquals('2017-01-04 00:00:00', $users[0]->getCreatedate());
     }
 
     public function testGetSelectFunction()
@@ -168,14 +169,14 @@ class RepositoryTest extends TestCase
 
         $users = $this->repository->get(1);
         $this->assertEquals(1, $users->getId());
-        $this->assertEquals('[JOHN DOE] - 2017-01-02', $users->getName());
-        $this->assertEquals('2017-01-02', $users->getCreatedate());
+        $this->assertEquals('[JOHN DOE] - 2017-01-02 00:00:00', $users->getName());
+        $this->assertEquals('2017-01-02 00:00:00', $users->getCreatedate());
         $this->assertEquals(2017, $users->getYear());
 
         $users = $this->repository->get(2);
         $this->assertEquals(2, $users->getId());
-        $this->assertEquals('[JANE DOE] - 2017-01-04', $users->getName());
-        $this->assertEquals('2017-01-04', $users->getCreatedate());
+        $this->assertEquals('[JANE DOE] - 2017-01-04 00:00:00', $users->getName());
+        $this->assertEquals('2017-01-04 00:00:00', $users->getCreatedate());
         $this->assertEquals(2017, $users->getYear());
     }
 
@@ -237,7 +238,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(4, $users2->getId());
         $this->assertEquals('Bla99991919', $users2->getName());
-        $this->assertEquals('2015-08-09', $users2->getCreatedate());
+        $this->assertEquals('2015-08-09 00:00:00', $users2->getCreatedate());
     }
 
     public function testInsertReadOnly()
@@ -272,7 +273,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(4, $users2->getId());
         $this->assertEquals('Bla-add', $users2->getName());
-        $this->assertEquals('2017-12-21', $users2->getCreatedate());
+        $this->assertEquals('2017-12-21 00:00:00', $users2->getCreatedate());
     }
 
     public function testInsertLiteral()
@@ -280,7 +281,7 @@ class RepositoryTest extends TestCase
         /** @var Users $users */
         $users = $this->repository->entity([
             "name" => new Literal("X'6565'"),
-            "createdate" => '2015-08-09'
+            "createdate" => '2015-08-09 12:13:14'
         ]);
 
         $this->assertEquals(null, $users->getId());
@@ -290,7 +291,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(4, $users2->getId());
         $this->assertEquals('ee', $users2->getName());
-        $this->assertEquals('2015-08-09', $users2->getCreatedate());
+        $this->assertEquals('2015-08-09 12:13:14', $users2->getCreatedate());
 
         $this->assertEquals($users2->getId(), $users->getId());
         $this->assertEquals($users2->getCreatedate(), $users->getCreatedate());
@@ -319,7 +320,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(4, $users2->getId());
         $this->assertEquals('ee', $users2->getName());
-        $this->assertEquals('2015-08-09', $users2->getCreatedate());
+        $this->assertEquals('2015-08-09 00:00:00', $users2->getCreatedate());
     }
 
     public function testInsertKeyGen()
@@ -345,7 +346,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(50, $users2->getId());
         $this->assertEquals('Bla99991919', $users2->getName());
-        $this->assertEquals('2015-08-09', $users2->getCreatedate());
+        $this->assertEquals('2015-08-09 00:00:00', $users2->getCreatedate());
     }
 
     public function testInsertUpdateFunction()
@@ -379,7 +380,7 @@ class RepositoryTest extends TestCase
         $users2 = $this->repository->get(4);
 
         $this->assertEquals(4, $users2->getId());
-        $this->assertEquals('2015-08-09', $users2->getCreatedate());
+        $this->assertEquals('2015-08-09 00:00:00', $users2->getCreatedate());
         $this->assertEquals(2015, $users2->getYear());
         $this->assertEquals('Sr. John Doe - 2015-08-09', $users2->getName());
     }
@@ -395,12 +396,12 @@ class RepositoryTest extends TestCase
         $users2 = $this->repository->get(1);
         $this->assertEquals(1, $users2->getId());
         $this->assertEquals('New Name', $users2->getName());
-        $this->assertEquals('2016-01-09', $users2->getCreatedate());
+        $this->assertEquals('2016-01-09 00:00:00', $users2->getCreatedate());
 
         $users2 = $this->repository->get(2);
         $this->assertEquals(2, $users2->getId());
         $this->assertEquals('Jane Doe', $users2->getName());
-        $this->assertEquals('2017-01-04', $users2->getCreatedate());
+        $this->assertEquals('2017-01-04 00:00:00', $users2->getCreatedate());
     }
 
     public function testUpdateReadOnly()
@@ -446,7 +447,7 @@ class RepositoryTest extends TestCase
 
         $users = $this->repository->get(4);
         $this->assertEquals('inserted name', $users->getName());
-        $this->assertEquals('2024-09-03', $users->getCreatedate());
+        $this->assertEquals('2024-09-03 00:00:00', $users->getCreatedate());
     }
 
     public function testInsertBuildAndExecute2()
@@ -463,7 +464,7 @@ class RepositoryTest extends TestCase
 
         $users = $this->repository->get(4);
         $this->assertEquals('inserted name', $users->getName());
-        $this->assertEquals('2024-09-03', $users->getCreatedate());
+        $this->assertEquals('2024-09-03 00:00:00', $users->getCreatedate());
     }
 
     public function testDeleteBuildAndExecute()
@@ -497,12 +498,12 @@ class RepositoryTest extends TestCase
         $users2 = $this->repository->get(1);
         $this->assertEquals(1, $users2->getId());
         $this->assertEquals('New Name-upd', $users2->getName());
-        $this->assertEquals('2017-12-21', $users2->getCreatedate());
+        $this->assertEquals('2017-12-21 00:00:00', $users2->getCreatedate());
 
         $users2 = $this->repository->get(2);
         $this->assertEquals(2, $users2->getId());
         $this->assertEquals('Jane Doe', $users2->getName());
-        $this->assertEquals('2017-01-04', $users2->getCreatedate());
+        $this->assertEquals('2017-01-04 00:00:00', $users2->getCreatedate());
     }
 
     public function testUpdateLiteral()
@@ -515,7 +516,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(1, $users2->getId());
         $this->assertEquals('ee', $users2->getName());
-        $this->assertEquals('2017-01-02', $users2->getCreatedate());
+        $this->assertEquals('2017-01-02 00:00:00', $users2->getCreatedate());
     }
 
     public function testUpdateObject()
@@ -541,7 +542,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(1, $users2->getId());
         $this->assertEquals('ee', $users2->getName());
-        $this->assertEquals('2020-01-02', $users2->getCreatedate());
+        $this->assertEquals('2020-01-02 00:00:00', $users2->getCreatedate());
     }
 
 
@@ -573,13 +574,13 @@ class RepositoryTest extends TestCase
         $users2 = $this->repository->get(1);
         $this->assertEquals(1, $users2->getId());
         $this->assertEquals('Sr. New Name', $users2->getName());
-        $this->assertEquals('2016-01-09', $users2->getCreatedate());
+        $this->assertEquals('2016-01-09 00:00:00', $users2->getCreatedate());
         $this->assertEquals(2016, $users2->getYear());
 
         $users2 = $this->repository->get(2);
         $this->assertEquals(2, $users2->getId());
         $this->assertEquals('Jane Doe', $users2->getName());
-        $this->assertEquals('2017-01-04', $users2->getCreatedate());
+        $this->assertEquals('2017-01-04 00:00:00', $users2->getCreatedate());
         $this->assertEquals(2017, $users2->getYear());
     }
 
@@ -592,7 +593,7 @@ class RepositoryTest extends TestCase
         $users = $this->repository->get(2);
         $this->assertEquals(2, $users->getId());
         $this->assertEquals('Jane Doe', $users->getName());
-        $this->assertEquals('2017-01-04', $users->getCreatedate());
+        $this->assertEquals('2017-01-04 00:00:00', $users->getCreatedate());
     }
 
     public function testDeleteReadOnly()
@@ -610,7 +611,7 @@ class RepositoryTest extends TestCase
         $users = $this->repository->get(2);
         $this->assertEquals(2, $users->getId());
         $this->assertEquals('Jane Doe', $users->getName());
-        $this->assertEquals('2017-01-04', $users->getCreatedate());
+        $this->assertEquals('2017-01-04 00:00:00', $users->getCreatedate());
     }
 
     public function testDelete2()
@@ -624,7 +625,7 @@ class RepositoryTest extends TestCase
         $users = $this->repository->get(1);
         $this->assertEquals(1, $users->getId());
         $this->assertEquals('John Doe', $users->getName());
-        $this->assertEquals('2017-01-02', $users->getCreatedate());
+        $this->assertEquals('2017-01-02 00:00:00', $users->getCreatedate());
 
         $users = $this->repository->get(2);
         $this->assertEmpty($users);
@@ -662,7 +663,7 @@ class RepositoryTest extends TestCase
         $infoRepository->save($result[0]);
 
         $result = $infoRepository->getByQuery($query);
-        $this->assertSame('0', (string)$result[0]->getValue());
+        $this->assertSame('0.00', (string)$result[0]->getValue());
 
         // Set Null
         $result[0]->setValue(null);
@@ -687,7 +688,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(2, $result[0]->getId());
         $this->assertEquals('Jane Doe', $result[0]->getName());
-        $this->assertEquals('2017-01-04', $result[0]->getCreatedate());
+        $this->assertEquals('2017-01-04 00:00:00', $result[0]->getCreatedate());
     }
 
     public function testFilterInTwo()
@@ -698,11 +699,11 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(2, $result[0]->getId());
         $this->assertEquals('Jane Doe', $result[0]->getName());
-        $this->assertEquals('2017-01-04', $result[0]->getCreatedate());
+        $this->assertEquals('2017-01-04 00:00:00', $result[0]->getCreatedate());
 
         $this->assertEquals(3, $result[1]->getId());
         $this->assertEquals('JG', $result[1]->getName());
-        $this->assertEquals('1974-01-26', $result[1]->getCreatedate());
+        $this->assertEquals('1974-01-26 00:00:00', $result[1]->getCreatedate());
     }
 
     /**
@@ -755,11 +756,11 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(1, $result[0][0]->getId());
         $this->assertEquals('John Doe', $result[0][0]->getName());
-        $this->assertEquals('2017-01-02', $result[0][0]->getCreatedate());
+        $this->assertEquals('2017-01-02 00:00:00', $result[0][0]->getCreatedate());
 
         $this->assertEquals(1, $result[1][0]->getId());
         $this->assertEquals('John Doe', $result[1][0]->getName());
-        $this->assertEquals('2017-01-02', $result[1][0]->getCreatedate());
+        $this->assertEquals('2017-01-02 00:00:00', $result[1][0]->getCreatedate());
 
         // - ------------------
 
@@ -788,7 +789,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(2, $result[0][0]->getId());
         $this->assertEquals('Jane Doe', $result[0][0]->getName());
-        $this->assertEquals('2017-01-04', $result[0][0]->getCreatedate());
+        $this->assertEquals('2017-01-04 00:00:00', $result[0][0]->getCreatedate());
 
         // - ------------------
 
@@ -805,7 +806,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(1, $result[0]->getId());
         $this->assertEquals('John Doe', $result[0]->getName());
-        $this->assertEquals('2017-01-02', $result[0]->getCreatedate());
+        $this->assertEquals('2017-01-02 00:00:00', $result[0]->getCreatedate());
 
         $this->assertEquals(1, count($result));
     }
@@ -819,7 +820,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(2, $result[0]->getId());
         $this->assertEquals('Jane Doe', $result[0]->getName());
-        $this->assertEquals('2017-01-04', $result[0]->getCreatedate());
+        $this->assertEquals('2017-01-04 00:00:00', $result[0]->getCreatedate());
 
         $this->assertEquals(1, count($result));
     }
@@ -829,7 +830,7 @@ class RepositoryTest extends TestCase
         $query = $this->repository->queryInstance()
             ->fields([
                 "name",
-                "julianday('2020-06-28') - julianday(createdate) as days"
+                "DATEDIFF('2020-06-28', createdate) AS days"
             ])
             ->limit(1, 1);
 
@@ -1234,15 +1235,17 @@ class RepositoryTest extends TestCase
         $this->assertEquals(3, $result[0]->getPk());
         $this->assertEquals(3, $result[0]->iduser);
         $this->assertEquals(3.5, $result[0]->value);
-        $this->assertNull($result[0]->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($result[0]->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($result[0]->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertNotNull($result[0]->getCreatedAt());
+        $this->assertNotNull($result[0]->getUpdatedAt());
+        $this->assertNull($result[0]->getDeletedAt());
+        $this->assertEquals($result[0]->getCreatedAt(), $result[0]->getUpdatedAt()); 
     }
 
     public function testMappingAttributeInsert()
     {
         $infoRepository = new Repository($this->dbDriver, ModelWithAttributes::class);
 
+        // Sanity check
         $query = new Query();
         $query->table($this->infoMapper->getTable())
             ->where('iduser = :id', ['id' => 123])
@@ -1250,11 +1253,13 @@ class RepositoryTest extends TestCase
         $result = $infoRepository->getByQuery($query);
         $this->assertEmpty($result);
 
+        // Add a new record
         $info = new ModelWithAttributes();
         $info->iduser = 123;
         $info->value = 98.5;
         $infoRepository->save($info);
 
+        // Get the Record and assert the values
         /** @var ModelWithAttributes[] $result */
         $result = $infoRepository->getByQuery($query);
         $this->assertEquals(count($result), 1);
@@ -1266,10 +1271,12 @@ class RepositoryTest extends TestCase
         $this->assertNotNull($result[0]->getUpdatedAt());
         $this->assertNull($result[0]->getDeletedAt());
 
-        // Check if the updated_at works
+        // save the record again and assert the values
         sleep(1);
         $info->value = 99.5;
         $infoRepository->save($info);
+
+        // Get directly from the databae
         /** @var ModelWithAttributes[] $result2 */
         $result2 = $infoRepository->getByQuery($query);
         $this->assertEquals(count($result2), 1);
@@ -1296,14 +1303,19 @@ class RepositoryTest extends TestCase
         $this->assertEquals(3, $result[0]->getPk());
         $this->assertEquals(3, $result[0]->iduser);
         $this->assertEquals(3.5, $result[0]->value);
-        $this->assertNull($result[0]->getCreatedAt());
-        $this->assertNull($result[0]->getUpdatedAt());
+        $this->assertNotNull($result[0]->getCreatedAt());
+        $this->assertNotNull($result[0]->getUpdatedAt());
         $this->assertNull($result[0]->getDeletedAt());
 
         $infoRepository->delete(3);
 
         $result = $infoRepository->getByQuery($query);
         $this->assertCount(0, $result);
+
+        $query->unsafe();
+        $result = $infoRepository->getByQuery($query);
+        $this->assertCount(1, $result);
+        $this->assertNotNull($result[0]->getDeletedAt());
     }
 
     public function testMappingAttributeSoftDeleteAndGetByFilter()
@@ -1317,8 +1329,8 @@ class RepositoryTest extends TestCase
         $this->assertEquals(3, $result[0]->getPk());
         $this->assertEquals(3, $result[0]->iduser);
         $this->assertEquals(3.5, $result[0]->value);
-        $this->assertNull($result[0]->getCreatedAt());
-        $this->assertNull($result[0]->getUpdatedAt());
+        $this->assertNotNull($result[0]->getCreatedAt());
+        $this->assertNotNull($result[0]->getUpdatedAt());
         $this->assertNull($result[0]->getDeletedAt());
 
         $infoRepository->delete(3);
@@ -1336,8 +1348,8 @@ class RepositoryTest extends TestCase
         $this->assertEquals(3, $result->getPk());
         $this->assertEquals(3, $result->iduser);
         $this->assertEquals(3.5, $result->value);
-        $this->assertNull($result->getCreatedAt());
-        $this->assertNull($result->getUpdatedAt());
+        $this->assertNotNull($result->getCreatedAt());
+        $this->assertNotNull($result->getUpdatedAt());
         $this->assertNull($result->getDeletedAt());
 
         $infoRepository->delete(3);
@@ -1360,7 +1372,7 @@ class RepositoryTest extends TestCase
 
         $this->assertEquals(3, $result[0]->getId());
         $this->assertEquals('JG', $result[0]->getName());
-        $this->assertEquals('1974-01-26', $result[0]->getCreatedate());
+        $this->assertEquals('1974-01-26 00:00:00', $result[0]->getCreatedate());
 
     }
 
@@ -1449,9 +1461,9 @@ class RepositoryTest extends TestCase
         $this->assertEquals(3, $model->getPk());
         $this->assertEquals(3, $model->iduser);
         $this->assertEquals(3.5, $model->value);
-        $this->assertNull($model->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertNotNull($model->getCreatedAt());
+        $this->assertNotNull($model->getUpdatedAt());
+        $this->assertNull($model->getDeletedAt()); 
     }
 
     public function testActiveRecordRefresh()
@@ -1472,9 +1484,9 @@ class RepositoryTest extends TestCase
         $this->assertEquals(3, $model->getPk());
         $this->assertEquals(3, $model->iduser);
         $this->assertEquals(3.5, $model->value);
-        $this->assertNull($createdAt); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($updatedAt); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($deletedAt); // Because it was not set in the initial insert outside the ORM
+        $this->assertNotNull($createdAt);
+        $this->assertNotNull($updatedAt);
+        $this->assertNull($deletedAt); 
 
         // Update the record OUTSIDE the Active Record
         $this->dbDriver->execute("UPDATE info SET iduser = 4, property = 44.44 WHERE id = 3");
@@ -1483,9 +1495,9 @@ class RepositoryTest extends TestCase
         $this->assertEquals(3, $model->getPk());
         $this->assertEquals(3, $model->iduser);
         $this->assertEquals(3.5, $model->value);
-        $this->assertEquals($createdAt, $model->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertEquals($updatedAt, $model->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertEquals($deletedAt, $model->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertEquals($createdAt, $model->getCreatedAt());
+        $this->assertEquals($updatedAt, $model->getUpdatedAt());
+        $this->assertEquals($deletedAt, $model->getDeletedAt()); 
 
         // Refresh the model
         $model->refresh();
@@ -1494,9 +1506,9 @@ class RepositoryTest extends TestCase
         $this->assertEquals(3, $model->getPk());
         $this->assertEquals(4, $model->iduser);
         $this->assertEquals(44.44, $model->value);
-        $this->assertEquals($createdAt, $model->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertEquals($updatedAt, $model->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertEquals($deletedAt, $model->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertEquals($createdAt, $model->getCreatedAt());
+        $this->assertEquals($updatedAt, $model->getUpdatedAt());
+        $this->assertEquals($deletedAt, $model->getDeletedAt()); 
     }
 
     public function testActiveRecordRefreshError()
@@ -1519,9 +1531,9 @@ class RepositoryTest extends TestCase
         $this->assertEquals(3, $model->getPk());
         $this->assertEquals(3, $model->iduser);
         $this->assertEquals(3.5, $model->value);
-        $this->assertNull($model->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertNotNull($model->getCreatedAt());
+        $this->assertNotNull($model->getUpdatedAt());
+        $this->assertNull($model->getDeletedAt()); 
 
         $model->fill([
             'iduser' => 4,
@@ -1531,9 +1543,9 @@ class RepositoryTest extends TestCase
         $this->assertEquals(3, $model->getPk());
         $this->assertEquals(4, $model->iduser);
         $this->assertEquals(44.44, $model->value);
-        $this->assertNull($model->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertNotNull($model->getCreatedAt());
+        $this->assertNotNull($model->getUpdatedAt());
+        $this->assertNull($model->getDeletedAt()); 
     }
 
 
@@ -1547,16 +1559,16 @@ class RepositoryTest extends TestCase
         $this->assertEquals(1, $model[0]->getPk());
         $this->assertEquals(1, $model[0]->iduser);
         $this->assertEquals(30.4, $model[0]->value);
-        $this->assertNull($model[0]->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model[0]->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model[0]->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertNotNull($model[0]->getCreatedAt());
+        $this->assertNotNull($model[0]->getUpdatedAt());
+        $this->assertNull($model[0]->getDeletedAt()); 
 
         $this->assertEquals(2, $model[1]->getPk());
         $this->assertEquals(1, $model[1]->iduser);
         $this->assertEquals(1250.96, $model[1]->value);
-        $this->assertNull($model[1]->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model[1]->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model[1]->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertNotNull($model[1]->getCreatedAt());
+        $this->assertNotNull($model[1]->getUpdatedAt());
+        $this->assertNull($model[1]->getDeletedAt()); 
     }
 
     public function testActiveRecordEmptyFilter()
@@ -1594,17 +1606,17 @@ class RepositoryTest extends TestCase
         $this->assertEquals(4, $model->getPk());
         $this->assertEquals(5, $model->iduser);
         $this->assertEquals(55.8, $model->value);
-        $this->assertNotNull($model->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNotNull($model->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertNotNull($model->getCreatedAt());
+        $this->assertNotNull($model->getUpdatedAt());
+        $this->assertNull($model->getDeletedAt()); 
 
         $model = ActiveRecordModel::get(4);
         $this->assertEquals(4, $model->getPk());
         $this->assertEquals(5, $model->iduser);
         $this->assertEquals(55.8, $model->value);
-        $this->assertNotNull($model->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNotNull($model->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertNotNull($model->getCreatedAt());
+        $this->assertNotNull($model->getUpdatedAt());
+        $this->assertNull($model->getDeletedAt()); 
     }
 
     public function testActiveRecordUpdate()
@@ -1620,17 +1632,17 @@ class RepositoryTest extends TestCase
         $this->assertEquals(3, $model->getPk());
         $this->assertEquals(3, $model->iduser);
         $this->assertEquals(99.1, $model->value);
-        $this->assertNull($model->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNotNull($model->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertNotNull($model->getCreatedAt());
+        $this->assertNotNull($model->getUpdatedAt());
+        $this->assertNull($model->getDeletedAt()); 
 
         $model = ActiveRecordModel::get(3);
         $this->assertEquals(3, $model->getPk());
         $this->assertEquals(3, $model->iduser);
         $this->assertEquals(99.1, $model->value);
-        $this->assertNull($model->getCreatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNotNull($model->getUpdatedAt()); // Because it was not set in the initial insert outside the ORM
-        $this->assertNull($model->getDeletedAt()); // Because it was not set in the initial insert outside the ORM
+        $this->assertNotNull($model->getCreatedAt());
+        $this->assertNotNull($model->getUpdatedAt());
+        $this->assertNull($model->getDeletedAt()); 
     }
 
     public function testActiveRecordDelete()

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -5,7 +5,6 @@ namespace Tests;
 use ByJG\AnyDataset\Core\Enum\Relation;
 use ByJG\AnyDataset\Core\IteratorFilter;
 use ByJG\AnyDataset\Db\DbDriverInterface;
-use ByJG\AnyDataset\Db\Factory;
 use ByJG\Cache\Psr16\ArrayCacheEngine;
 use ByJG\MicroOrm\CacheQueryResult;
 use ByJG\MicroOrm\DeleteQuery;
@@ -44,9 +43,6 @@ use Throwable;
 
 class RepositoryTest extends TestCase
 {
-
-    const URI = 'mysql://root:password@127.0.0.1';
-
     /**
      * @var Mapper
      */
@@ -69,9 +65,7 @@ class RepositoryTest extends TestCase
 
     public function setUp(): void
     {
-        $this->dbDriver = Factory::getDbInstance(self::URI);
-        $this->dbDriver->execute('create database if not exists testmicroorm;');
-        $this->dbDriver = Factory::getDbInstance(self::URI . "/testmicroorm");
+        $this->dbDriver = ConnectionUtil::getConnection("testmicroorm");
 
         $this->dbDriver->execute('create table users (
             id integer primary key  auto_increment,

--- a/tests/RepositoryUuidTest.php
+++ b/tests/RepositoryUuidTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use ByJG\AnyDataset\Db\DbDriverInterface;
-use ByJG\AnyDataset\Db\Factory;
 use ByJG\MicroOrm\Literal\HexUuidLiteral;
 use ByJG\MicroOrm\Repository;
 use PHPUnit\Framework\TestCase;
@@ -11,9 +10,6 @@ use Tests\Model\UsersWithUuidKey;
 
 class RepositoryUuidTest extends TestCase
 {
-
-    const URI = 'mysql://root:password@127.0.0.1';
-
     /**
      * @var DbDriverInterface
      */
@@ -26,9 +22,7 @@ class RepositoryUuidTest extends TestCase
 
     public function setUp(): void
     {
-        $this->dbDriver = Factory::getDbInstance(self::URI);
-        $this->dbDriver->execute('create database if not exists testmicroorm;');
-        $this->dbDriver = Factory::getDbInstance(self::URI . "/testmicroorm");
+        $this->dbDriver = ConnectionUtil::getConnection("testmicroorm");
 
         $this->dbDriver->execute('create table usersuuid (
             id binary(16) primary key,

--- a/tests/RepositoryUuidTest.php
+++ b/tests/RepositoryUuidTest.php
@@ -6,14 +6,13 @@ use ByJG\AnyDataset\Db\DbDriverInterface;
 use ByJG\AnyDataset\Db\Factory;
 use ByJG\MicroOrm\Literal\HexUuidLiteral;
 use ByJG\MicroOrm\Repository;
-use ByJG\Util\Uri;
 use PHPUnit\Framework\TestCase;
 use Tests\Model\UsersWithUuidKey;
 
 class RepositoryUuidTest extends TestCase
 {
 
-    const URI='sqlite:///tmp/test.db';
+    const URI = 'mysql://root:password@127.0.0.1';
 
     /**
      * @var DbDriverInterface
@@ -28,6 +27,8 @@ class RepositoryUuidTest extends TestCase
     public function setUp(): void
     {
         $this->dbDriver = Factory::getDbInstance(self::URI);
+        $this->dbDriver->execute('create database if not exists testmicroorm;');
+        $this->dbDriver = Factory::getDbInstance(self::URI . "/testmicroorm");
 
         $this->dbDriver->execute('create table usersuuid (
             id binary(16) primary key,
@@ -38,8 +39,7 @@ class RepositoryUuidTest extends TestCase
 
     public function tearDown(): void
     {
-        $uri = new Uri(self::URI);
-        unlink($uri->getPath());
+        $this->dbDriver->execute('drop table if exists usersuuid;');
     }
 
     public function testGet()

--- a/tests/TransactionManagerTest.php
+++ b/tests/TransactionManagerTest.php
@@ -21,6 +21,11 @@ class TransactionManagerTest extends TestCase
     public function setUp(): void
     {
         $this->object = new TransactionManager();
+
+        ConnectionUtil::getConnection("a");
+        ConnectionUtil::getConnection("b");
+        ConnectionUtil::getConnection("c");
+        ConnectionUtil::getConnection("d");
     }
 
     public function tearDown(): void

--- a/tests/TransactionManagerTest.php
+++ b/tests/TransactionManagerTest.php
@@ -46,16 +46,16 @@ class TransactionManagerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("The connection already exists with a different instance");
 
-        $dbDrive1 = $this->object->addConnection(ConnectionUtil::getUri("a"));
-        $dbDrive2 = $this->object->addConnection(ConnectionUtil::getUri("b"));
-        $dbDrive3 = $this->object->addConnection(ConnectionUtil::getUri("a"));
-        $dbDrive4 = $this->object->addConnection(ConnectionUtil::getUri("b"));
+        $dbDrive1 = $this->object->addConnection(ConnectionUtil::getUri("a")->__toString());
+        $dbDrive2 = $this->object->addConnection(ConnectionUtil::getUri("b")->__toString());
+        $dbDrive3 = $this->object->addConnection(ConnectionUtil::getUri("a")->__toString());
+        $dbDrive4 = $this->object->addConnection(ConnectionUtil::getUri("b")->__toString());
     }
 
     public function testAddConnection()
     {
-        $dbDrive1 = $this->object->addConnection(ConnectionUtil::getUri("a"));
-        $dbDrive2 = $this->object->addConnection(ConnectionUtil::getUri("b"));
+        $dbDrive1 = $this->object->addConnection(ConnectionUtil::getUri("a")->__toString());
+        $dbDrive2 = $this->object->addConnection(ConnectionUtil::getUri("b")->__toString());
         $this->object->addDbDriver($dbDrive1);
         $this->object->addDbDriver($dbDrive2);
 
@@ -119,8 +119,8 @@ class TransactionManagerTest extends TestCase
 
     public function testBeginTransaction()
     {
-        $this->object->addConnection(ConnectionUtil::getUri("c"));
-        $this->object->addConnection(ConnectionUtil::getUri("d"));
+        $this->object->addConnection(ConnectionUtil::getUri("c")->__toString());
+        $this->object->addConnection(ConnectionUtil::getUri("d")->__toString());
 
         $this->object->beginTransaction();
         $this->object->commitTransaction();
@@ -133,8 +133,8 @@ class TransactionManagerTest extends TestCase
         $this->expectException(TransactionException::class);
         $this->expectExceptionMessage("Transaction Already Started");
 
-        $this->object->addConnection(ConnectionUtil::getUri("a"));
-        $this->object->addConnection(ConnectionUtil::getUri("d"));
+        $this->object->addConnection(ConnectionUtil::getUri("a")->__toString());
+        $this->object->addConnection(ConnectionUtil::getUri("d")->__toString());
 
         $this->assertEquals(2, $this->object->count());
 
@@ -147,7 +147,7 @@ class TransactionManagerTest extends TestCase
         $this->expectException(TransactionException::class);
         $this->expectExceptionMessage("There is no Active Transaction");
 
-        $this->object->addConnection(ConnectionUtil::getUri("c"));
+        $this->object->addConnection(ConnectionUtil::getUri("c")->__toString());
         $this->assertEquals(1, $this->object->count());
         $this->object->rollbackTransaction();
     }
@@ -157,7 +157,7 @@ class TransactionManagerTest extends TestCase
         $this->expectException(TransactionException::class);
         $this->expectExceptionMessage("There is no Active Transaction");
 
-        $this->object->addConnection(ConnectionUtil::getUri("d"));
+        $this->object->addConnection(ConnectionUtil::getUri("d")->__toString());
         $this->assertEquals(1, $this->object->count());
         $this->object->commitTransaction();
     }


### PR DESCRIPTION
This pull request includes the following changes:

- Introduced `bulkExecute` method in the Repository class for atomic execution of multiple write queries (insert, update, delete) within a transaction. It includes support for optional isolation levels, detailed exception handling, and validation.
- Extended build methods to accept the `DbDriverInterface` for better flexibility.
- Added tests for MySQL alias handling and subquery joins.
- Updated documentation and included unit tests to ensure reliability and correctness.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add support for executing multiple write queries in bulk within a single transaction and improve database interface compatibility in query building.

### Why are these changes being made?
This change addresses the need for atomic operations where multiple database write actions (inserts, updates, deletes) must either all succeed or all fail as a group, ensuring data integrity. The enhancement to allow query building with both `DbFunctionsInterface` and `DbDriverInterface` increases flexibility, enabling more robust database operations across different database drivers. New functionality and test coverage ensure robustness and address parameter overlaps and error states.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->